### PR TITLE
Changed Export- and Import Button Order

### DIFF
--- a/lib/views/settings_view.dart
+++ b/lib/views/settings_view.dart
@@ -111,6 +111,37 @@ class _SettingsViewState extends State<SettingsView> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         CupertinoButton(
+                            color: CustomTheme.primaryColor,
+                            sizeStyle: CupertinoButtonSize.medium,
+                            child: Text(
+                              'Daten importieren',
+                              style:
+                                  TextStyle(color: CustomTheme.backgroundColor),
+                            ),
+                            onPressed: () async {
+                              final success =
+                                  await LocalStorageService.importJsonFile();
+                              if (!success && context.mounted) {
+                                showCupertinoDialog(
+                                    context: context,
+                                    builder: (context) => CupertinoAlertDialog(
+                                          title: const Text('Fehler'),
+                                          content: const Text(
+                                              'Datei konnte nicht importiert werden.'),
+                                          actions: [
+                                            CupertinoDialogAction(
+                                              child: const Text('OK'),
+                                              onPressed: () =>
+                                                  Navigator.pop(context),
+                                            ),
+                                          ],
+                                        ));
+                              }
+                            }),
+                        const SizedBox(
+                          width: 20,
+                        ),
+                        CupertinoButton(
                           color: CustomTheme.primaryColor,
                           sizeStyle: CupertinoButtonSize.medium,
                           child: Text(
@@ -119,7 +150,6 @@ class _SettingsViewState extends State<SettingsView> {
                                 TextStyle(color: CustomTheme.backgroundColor),
                           ),
                           onPressed: () async {
-                            print('Export pressed');
                             final success =
                                 await LocalStorageService.exportJsonFile();
                             if (!success && context.mounted) {
@@ -140,38 +170,6 @@ class _SettingsViewState extends State<SettingsView> {
                             }
                           },
                         ),
-                        const SizedBox(
-                          width: 20,
-                        ),
-                        CupertinoButton(
-                            color: CustomTheme.primaryColor,
-                            sizeStyle: CupertinoButtonSize.medium,
-                            child: Text(
-                              'Daten importieren',
-                              style:
-                                  TextStyle(color: CustomTheme.backgroundColor),
-                            ),
-                            onPressed: () async {
-                              print('Import pressed');
-                              final success =
-                                  await LocalStorageService.importJsonFile();
-                              if (!success && context.mounted) {
-                                showCupertinoDialog(
-                                    context: context,
-                                    builder: (context) => CupertinoAlertDialog(
-                                          title: const Text('Fehler'),
-                                          content: const Text(
-                                              'Datei konnte nicht importiert werden.'),
-                                          actions: [
-                                            CupertinoDialogAction(
-                                              child: const Text('OK'),
-                                              onPressed: () =>
-                                                  Navigator.pop(context),
-                                            ),
-                                          ],
-                                        ));
-                              }
-                            }),
                       ],
                     )),
               )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.2.8+201
+version: 0.2.8+202
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.2.8+202
+version: 0.2.9+203
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Changed Export- and Import Button Order

**Related Issue(s):**  
Closes #40 

## Description  
Changed the order of the export- and import-button in the `SettingsView` because it benefits the UX and shows the sequence in which its normally done (First import, after a while export)

## Changes Made  
- [x] Updated button order 
