### PR TITLE
Graph Enhancements

### DIFF
--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -74,7 +74,6 @@
   "done": "Fertig",
   "next_round": "Nächste Runde",
 
-  "statistics": "Statistiken",
   "end_game": "Spiel beenden",
   "delete_game": "Spiel löschen",
   "new_game_same_settings": "Neues Spiel mit gleichen Einstellungen",
@@ -85,7 +84,7 @@
   "end_game_message": "Möchtest du das Spiel beenden? Das Spiel wird als beendet markiert und kann nicht fortgeführt werden.",
 
   "game_process": "Spielverlauf",
-  "empty_graph_text": "Du musst mindestens zwei Runden spielen, damit der Graph des Spielverlaufes angezeigt werden kann.",
+  "empty_graph_text": "Du musst mindestens eine Runde spielen, damit der Graph des Spielverlaufes angezeigt werden kann.",
 
   "settings": "Einstellungen",
   "cabo_penalty": "Cabo-Strafe",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -74,8 +74,6 @@
   "done": "Done",
   "next_round": "Next Round",
 
-
-  "statistics": "Statistics",
   "end_game": "End Game",
   "delete_game": "Delete Game",
   "new_game_same_settings": "New Game with same Settings",
@@ -86,7 +84,7 @@
   "end_game_message": "Do you want to end the game? The game gets marked as finished and cannot be continued.",
 
   "game_process": "Scoring History",
-  "empty_graph_text": "You must play at least two rounds for the game progress graph to be displayed.",
+  "empty_graph_text": "You must play at least one round for the game progress graph to be displayed.",
 
   "settings": "Settings",
   "cabo_penalty": "Cabo Penalty",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -416,12 +416,6 @@ abstract class AppLocalizations {
   /// **'Nächste Runde'**
   String get next_round;
 
-  /// No description provided for @statistics.
-  ///
-  /// In de, this message translates to:
-  /// **'Statistiken'**
-  String get statistics;
-
   /// No description provided for @end_game.
   ///
   /// In de, this message translates to:

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -479,7 +479,7 @@ abstract class AppLocalizations {
   /// No description provided for @empty_graph_text.
   ///
   /// In de, this message translates to:
-  /// **'Du musst mindestens zwei Runden spielen, damit der Graph des Spielverlaufes angezeigt werden kann.'**
+  /// **'Du musst mindestens eine Runde spielen, damit der Graph des Spielverlaufes angezeigt werden kann.'**
   String get empty_graph_text;
 
   /// No description provided for @settings.

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -179,9 +179,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get next_round => 'Nächste Runde';
 
   @override
-  String get statistics => 'Statistiken';
-
-  @override
   String get end_game => 'Spiel beenden';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -212,7 +212,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get empty_graph_text =>
-      'Du musst mindestens zwei Runden spielen, damit der Graph des Spielverlaufes angezeigt werden kann.';
+      'Du musst mindestens eine Runde spielen, damit der Graph des Spielverlaufes angezeigt werden kann.';
 
   @override
   String get settings => 'Einstellungen';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -209,7 +209,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get empty_graph_text =>
-      'You must play at least two rounds for the game progress graph to be displayed.';
+      'You must play at least one round for the game progress graph to be displayed.';
 
   @override
   String get settings => 'Settings';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -176,9 +176,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get next_round => 'Next Round';
 
   @override
-  String get statistics => 'Statistics';
-
-  @override
   String get end_game => 'End Game';
 
   @override

--- a/lib/presentation/views/active_game_view.dart
+++ b/lib/presentation/views/active_game_view.dart
@@ -121,7 +121,7 @@ class _ActiveGameViewState extends State<ActiveGameView> {
                         children: [
                           CupertinoListTile(
                               title: Text(
-                                AppLocalizations.of(context).statistics,
+                                AppLocalizations.of(context).game_process,
                               ),
                               backgroundColorActivated:
                                   CustomTheme.backgroundColor,
@@ -131,8 +131,9 @@ class _ActiveGameViewState extends State<ActiveGameView> {
                                       builder: (_) => GraphView(
                                             gameSession: gameSession,
                                           )))),
-                          if (!gameSession.isPointsLimitEnabled)
-                            CupertinoListTile(
+                          Visibility(
+                            visible: !gameSession.isPointsLimitEnabled,
+                            child: CupertinoListTile(
                                 title: Text(
                                   AppLocalizations.of(context).end_game,
                                   style: gameSession.roundNumber > 1 &&
@@ -148,6 +149,7 @@ class _ActiveGameViewState extends State<ActiveGameView> {
                                     _showEndGameDialog();
                                   }
                                 }),
+                          ),
                           CupertinoListTile(
                             title: Text(
                               AppLocalizations.of(context).delete_game,

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -88,15 +88,28 @@ class _GraphViewState extends State<GraphView> {
     /// Each series contains data points for each round
     return List.generate(playerCount, (i) {
       final data = List.generate(
+        cumulativeScores[i].length + 1,
+        (j) => (
+          j,
+          j == 0
+              ? 0 // 0 Points at at the start of the game
+
+              // Adds a small jitter to the cumulative scores to prevent overlapping data points in the graph.
+              // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.
+              : cumulativeScores[i][j - 1] + (i - playerCount ~/ 2) * jitterStep
+        ),
+      ); /*List.generate(
         cumulativeScores[i].length,
         (j) => (
-          j + 1,
-
-          // Add a small jitter to the cumulative scores to prevent overlapping data points in the graph.
-          // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.
-          cumulativeScores[i][j] + (i - playerCount ~/ 2) * jitterStep
+          j,
+          j == 0
+              ? 0 // In Runde 0 immer 0 Punkte
+              :
+              // Add a small jitter to the cumulative scores to prevent overlapping data points in the graph.
+              // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.
+              cumulativeScores[i][j] + (i - playerCount ~/ 2) * jitterStep
         ),
-      );
+      );*/
 
       /// Create a LineSeries for the player
       /// The xValueMapper maps the round number, and the yValueMapper maps the cumulative score.

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -40,7 +40,10 @@ class _GraphViewState extends State<GraphView> {
                     interval: 1,
                     decimalPlaces: 0,
                   ),
-                  primaryYAxis: const NumericAxis(),
+                  primaryYAxis: const NumericAxis(
+                    interval: 1,
+                    decimalPlaces: 0,
+                  ),
                   series: getCumulativeScores(),
                 ),
               )
@@ -82,7 +85,7 @@ class _GraphViewState extends State<GraphView> {
       }
     }
 
-    const double jitterStep = 0.05;
+    const double jitterStep = 0.03;
 
     /// Create a list of LineSeries for each player
     /// Each series contains data points for each round
@@ -91,8 +94,8 @@ class _GraphViewState extends State<GraphView> {
         cumulativeScores[i].length + 1,
         (j) => (
           j,
-          j == 0
-              ? 0 // 0 Points at at the start of the game
+          j == 0 || cumulativeScores[i][j - 1] == 0
+              ? 0 // 0 Points at at the start of the game OR value is 0 (dont subtract jitter step)
 
               // Adds a small jitter to the cumulative scores to prevent overlapping data points in the graph.
               // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -30,7 +30,7 @@ class _GraphViewState extends State<GraphView> {
           middle: Text(AppLocalizations.of(context).game_process),
           previousPageTitle: AppLocalizations.of(context).back,
         ),
-        child: widget.gameSession.roundNumber > 2
+        child: widget.gameSession.roundNumber > 1
             ? Padding(
                 padding: const EdgeInsets.fromLTRB(0, 100, 0, 0),
                 child: SfCartesianChart(

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -97,7 +97,7 @@ class _GraphViewState extends State<GraphView> {
         (j) => (
           j,
           j == 0 || cumulativeScores[i][j - 1] == 0
-              ? 0 // 0 Points at at the start of the game OR value is 0 (dont subtract jitter step)
+              ? 0 // 0 points at the start of the game or when the value is 0 (don't subtract jitter step)
 
               // Adds a small jitter to the cumulative scores to prevent overlapping data points in the graph.
               // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -98,18 +98,7 @@ class _GraphViewState extends State<GraphView> {
               // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.
               : cumulativeScores[i][j - 1] + (i - playerCount ~/ 2) * jitterStep
         ),
-      ); /*List.generate(
-        cumulativeScores[i].length,
-        (j) => (
-          j,
-          j == 0
-              ? 0 // In Runde 0 immer 0 Punkte
-              :
-              // Add a small jitter to the cumulative scores to prevent overlapping data points in the graph.
-              // The jitter is centered around zero by subtracting playerCount ~/ 2 from the player index i.
-              cumulativeScores[i][j] + (i - playerCount ~/ 2) * jitterStep
-        ),
-      );*/
+      );
 
       /// Create a LineSeries for the player
       /// The xValueMapper maps the round number, and the yValueMapper maps the cumulative score.

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -35,7 +35,9 @@ class _GraphViewState extends State<GraphView> {
                 padding: const EdgeInsets.fromLTRB(0, 100, 0, 0),
                 child: SfCartesianChart(
                   legend: const Legend(
-                      isVisible: true, position: LegendPosition.bottom),
+                      overflowMode: LegendItemOverflowMode.wrap,
+                      isVisible: true,
+                      position: LegendPosition.bottom),
                   primaryXAxis: const NumericAxis(
                     interval: 1,
                     decimalPlaces: 0,

--- a/lib/presentation/views/graph_view.dart
+++ b/lib/presentation/views/graph_view.dart
@@ -82,7 +82,7 @@ class _GraphViewState extends State<GraphView> {
       }
     }
 
-    const double jitterStep = 0.15;
+    const double jitterStep = 0.05;
 
     /// Create a list of LineSeries for each player
     /// Each series contains data points for each round

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.4.3+479
+version: 0.4.3+481
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.4.4+484
+version: 0.4.4+485
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.4.3+483
+version: 0.4.4+484
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.4.3+481
+version: 0.4.3+483
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Graph Enhancements

**Related Issue(s):**  
Closes #100 

## Description  
Changed some details on the graph view to make it more intuitive and visually appearing 

## Changes Made  
- Adjustet jitter step in graph (0.03)
- Let rounds in graph start at round 0 with every player having 0 points there
- No decimals in Y-Axis
- Reworked jitter step:
  - jitter step is now smaller
  - if the value in the graph is 0, the jitter step wont be applied
- Removed overflow ui error in the graph legend
- Changed title of `GraphView` in `ActiveGameView`