### PR TITLE
Rework kamikaze feature

### DIFF
--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -71,6 +71,7 @@
   "results": "Ergebnisse",
   "who_said_cabo": "Wer hat CABO gesagt?",
   "kamikaze": "Kamikaze",
+  "who_has_kamikaze": "Wer hat Kamikaze?",
   "done": "Fertig",
   "next_round": "Nächste Runde",
   "bonus_points_title": "Bonus-Punkte!",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -71,6 +71,7 @@
   "results": "Results",
   "who_said_cabo": "Who called Cabo?",
   "kamikaze": "Kamikaze",
+  "who_has_kamikaze": "Who has Kamikaze?",
   "done": "Done",
   "next_round": "Next Round",
   "bonus_points_title": "Bonus-Points!",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -404,6 +404,12 @@ abstract class AppLocalizations {
   /// **'Kamikaze'**
   String get kamikaze;
 
+  /// No description provided for @who_has_kamikaze.
+  ///
+  /// In de, this message translates to:
+  /// **'Wer hat Kamikaze?'**
+  String get who_has_kamikaze;
+
   /// No description provided for @done.
   ///
   /// In de, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -173,6 +173,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get kamikaze => 'Kamikaze';
 
   @override
+  String get who_has_kamikaze => 'Wer hat Kamikaze?';
+
+  @override
   String get done => 'Fertig';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -171,6 +171,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get kamikaze => 'Kamikaze';
 
   @override
+  String get who_has_kamikaze => 'Who has Kamikaze?';
+
+  @override
   String get done => 'Done';
 
   @override

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -154,6 +154,17 @@ class _RoundViewState extends State<RoundView> {
                         ),
                       ),
                     ),
+                    Center(
+                      child: CupertinoButton(
+                        onPressed: () async {
+                          if (await _showKamikazeSheet(context)) {
+                            if (!context.mounted) return;
+                            _endOfRoundNavigation(context, true);
+                          }
+                        },
+                        child: Text(AppLocalizations.of(context).kamikaze),
+                      ),
+                    ),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 20.0),
                       child: CupertinoListTile(
@@ -308,15 +319,8 @@ class _RoundViewState extends State<RoundView> {
                     children: [
                       CupertinoButton(
                         onPressed: _areRoundInputsValid()
-                            ? () async {
-                                List<int> bonusPlayersIndices = _finishRound();
-                                if (bonusPlayersIndices.isNotEmpty) {
-                                  await _showBonusPopup(
-                                      context, bonusPlayersIndices);
-                                }
-                                LocalStorageService.saveGameSessions();
-                                if (!context.mounted) return;
-                                Navigator.pop(context);
+                            ? () {
+                                _endOfRoundNavigation(context, false);
                               }
                             : null,
                         child: Text(AppLocalizations.of(context).done),
@@ -324,21 +328,8 @@ class _RoundViewState extends State<RoundView> {
                       if (!widget.gameSession.isGameFinished)
                         CupertinoButton(
                           onPressed: _areRoundInputsValid()
-                              ? () async {
-                                  List<int> bonusPlayersIndices =
-                                      _finishRound();
-                                  if (bonusPlayersIndices.isNotEmpty) {
-                                    await _showBonusPopup(
-                                        context, bonusPlayersIndices);
-                                  }
-                                  LocalStorageService.saveGameSessions();
-                                  if (widget.gameSession.isGameFinished &&
-                                      context.mounted) {
-                                    Navigator.pop(context);
-                                  } else if (context.mounted) {
-                                    Navigator.pop(
-                                        context, widget.roundNumber + 1);
-                                  }
+                              ? () {
+                                  _endOfRoundNavigation(context, true);
                                 }
                               : null,
                           child: Text(AppLocalizations.of(context).next_round),
@@ -399,6 +390,36 @@ class _RoundViewState extends State<RoundView> {
           (i) => winnerIndex + i + 1),
       ...List.generate(winnerIndex, (i) => i)
     ];
+  }
+
+  Future<bool> _showKamikazeSheet(BuildContext context) async {
+    return await showCupertinoModalPopup<bool?>(
+          context: context,
+          builder: (BuildContext context) {
+            return CupertinoActionSheet(
+              title: Text(AppLocalizations.of(context).kamikaze),
+              message: Text(AppLocalizations.of(context).who_has_kamikaze),
+              actions: widget.gameSession.players.asMap().entries.map((entry) {
+                final index = entry.key;
+                final name = entry.value;
+                return CupertinoActionSheetAction(
+                  onPressed: () {
+                    _kamikazePlayerIndex =
+                        _kamikazePlayerIndex == index ? null : index;
+                    Navigator.pop(context, true);
+                  },
+                  child: Text(name),
+                );
+              }).toList(),
+              cancelButton: CupertinoActionSheetAction(
+                onPressed: () => Navigator.pop(context, false),
+                isDestructiveAction: true,
+                child: Text(AppLocalizations.of(context).cancel),
+              ),
+            );
+          },
+        ) ??
+        false;
   }
 
   /// Focuses the next text field in the list of text fields.
@@ -519,6 +540,30 @@ class _RoundViewState extends State<RoundView> {
       );
     }
     return resultText;
+  }
+
+  /// Handles the navigation for the end of the round.
+  /// It checks for bonus players and shows a popup, saves the game session,
+  /// and navigates to the next round or back to the previous screen.
+  /// It takes the BuildContext [context] and a boolean [navigateToNextRound] to determine
+  /// if it should navigate to the next round or not.
+  Future<void> _endOfRoundNavigation(
+      BuildContext context, bool navigateToNextRound) async {
+    List<int> bonusPlayersIndices = _finishRound();
+    if (bonusPlayersIndices.isNotEmpty) {
+      await _showBonusPopup(context, bonusPlayersIndices);
+    }
+
+    LocalStorageService.saveGameSessions();
+
+    if (context.mounted) {
+      if (!navigateToNextRound || widget.gameSession.isGameFinished) {
+        Navigator.pop(context);
+        return;
+      } else {
+        Navigator.pop(context, widget.roundNumber + 1);
+      }
+    }
   }
 
   @override

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -155,28 +155,6 @@ class _RoundViewState extends State<RoundView> {
                         ),
                       ),
                     ),
-                    Center(
-                      heightFactor: 1,
-                      child: CupertinoButton(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 15, vertical: 0),
-                        borderRadius: BorderRadius.circular(12),
-                        color: CupertinoColors.systemRed,
-                        onPressed: () async {
-                          if (await _showKamikazeSheet(context)) {
-                            if (!context.mounted) return;
-                            _endOfRoundNavigation(context, true);
-                          }
-                        },
-                        child: Text(
-                          AppLocalizations.of(context).kamikaze,
-                          style: const TextStyle(
-                            color: CupertinoColors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 20.0),
                       child: CupertinoListTile(
@@ -310,6 +288,29 @@ class _RoundViewState extends State<RoundView> {
                           ),
                         );
                       },
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+                      child: Center(
+                        heightFactor: 1,
+                        child: CupertinoButton(
+                          sizeStyle: CupertinoButtonSize.medium,
+                          borderRadius: BorderRadius.circular(15),
+                          color: const Color(0xFF202020),
+                          onPressed: () async {
+                            if (await _showKamikazeSheet(context)) {
+                              if (!context.mounted) return;
+                              _endOfRoundNavigation(context, true);
+                            }
+                          },
+                          child: Text(
+                            AppLocalizations.of(context).kamikaze,
+                            style: const TextStyle(
+                              color: CupertinoColors.destructiveRed,
+                            ),
+                          ),
+                        ),
+                      ),
                     ),
                   ],
                 ),

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -74,21 +74,22 @@ class _RoundViewState extends State<RoundView> {
     return CupertinoPageScaffold(
       resizeToAvoidBottomInset: false,
       navigationBar: CupertinoNavigationBar(
-        transitionBetweenRoutes: true,
-        leading: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () =>
-              {LocalStorageService.saveGameSessions(), Navigator.pop(context)},
-          child: Text(AppLocalizations.of(context).cancel),
-        ),
-        middle: Text(AppLocalizations.of(context).results),
-        trailing: widget.gameSession.isGameFinished
-            ? const Icon(
+          transitionBetweenRoutes: true,
+          leading: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () => {
+              LocalStorageService.saveGameSessions(),
+              Navigator.pop(context)
+            },
+            child: Text(AppLocalizations.of(context).cancel),
+          ),
+          middle: Text(AppLocalizations.of(context).results),
+          trailing: Visibility(
+              visible: widget.gameSession.isGameFinished,
+              child: const Icon(
                 CupertinoIcons.lock,
                 size: 25,
-              )
-            : null,
-      ),
+              ))),
       child: Stack(
         children: [
           Positioned.fill(
@@ -155,14 +156,25 @@ class _RoundViewState extends State<RoundView> {
                       ),
                     ),
                     Center(
+                      heightFactor: 1,
                       child: CupertinoButton(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 15, vertical: 0),
+                        borderRadius: BorderRadius.circular(12),
+                        color: CupertinoColors.systemRed,
                         onPressed: () async {
                           if (await _showKamikazeSheet(context)) {
                             if (!context.mounted) return;
                             _endOfRoundNavigation(context, true);
                           }
                         },
-                        child: Text(AppLocalizations.of(context).kamikaze),
+                        child: Text(
+                          AppLocalizations.of(context).kamikaze,
+                          style: const TextStyle(
+                            color: CupertinoColors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
                       ),
                     ),
                     Padding(

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -115,7 +115,7 @@ class _RoundViewState extends State<RoundView> {
                         vertical: 10,
                       ),
                       child: SizedBox(
-                        height: 40,
+                        height: 60,
                         child: CupertinoSegmentedControl<int>(
                           unselectedColor: CustomTheme.backgroundTintColor,
                           selectedColor: CustomTheme.primaryColor,
@@ -131,7 +131,7 @@ class _RoundViewState extends State<RoundView> {
                               Padding(
                                 padding: const EdgeInsets.symmetric(
                                   horizontal: 6,
-                                  vertical: 6,
+                                  vertical: 8,
                                 ),
                                 child: FittedBox(
                                   fit: BoxFit.scaleDown,
@@ -152,27 +152,6 @@ class _RoundViewState extends State<RoundView> {
                               _caboPlayerIndex = value;
                             });
                           },
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 20.0),
-                      child: CupertinoListTile(
-                        title: Text(AppLocalizations.of(context).player),
-                        trailing: Row(
-                          children: [
-                            SizedBox(
-                                width: 100,
-                                child: Center(
-                                    child: Text(
-                                        AppLocalizations.of(context).points))),
-                            const SizedBox(width: 20),
-                            SizedBox(
-                                width: 80,
-                                child: Center(
-                                    child: Text(AppLocalizations.of(context)
-                                        .kamikaze))),
-                          ],
                         ),
                       ),
                     ),
@@ -212,77 +191,32 @@ class _RoundViewState extends State<RoundView> {
                               subtitle: Text(
                                   '${widget.gameSession.playerScores[originalIndex]}'
                                   ' ${AppLocalizations.of(context).points}'),
-                              trailing: Row(
-                                children: [
-                                  SizedBox(
-                                    width: 100,
-                                    child: CupertinoTextField(
-                                      maxLength: 3,
-                                      focusNode: _focusNodeList[originalIndex],
-                                      keyboardType:
-                                          const TextInputType.numberWithOptions(
-                                        signed: true,
-                                        decimal: false,
-                                      ),
-                                      inputFormatters: [
-                                        FilteringTextInputFormatter.digitsOnly,
-                                      ],
-                                      textInputAction: index ==
-                                              widget.gameSession.players
-                                                      .length -
-                                                  1
-                                          ? TextInputAction.done
-                                          : TextInputAction.next,
-                                      controller:
-                                          _scoreControllerList[originalIndex],
-                                      placeholder:
-                                          AppLocalizations.of(context).points,
-                                      textAlign: TextAlign.center,
-                                      onSubmitted: (_) =>
-                                          _focusNextTextfield(originalIndex),
-                                      onChanged: (_) => setState(() {}),
-                                    ),
+                              trailing: SizedBox(
+                                width: 100,
+                                child: CupertinoTextField(
+                                  maxLength: 3,
+                                  focusNode: _focusNodeList[originalIndex],
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                    signed: true,
+                                    decimal: false,
                                   ),
-                                  const SizedBox(width: 50),
-                                  GestureDetector(
-                                    onTap: () {
-                                      setState(() {
-                                        _kamikazePlayerIndex =
-                                            (_kamikazePlayerIndex ==
-                                                    originalIndex)
-                                                ? null
-                                                : originalIndex;
-                                      });
-                                    },
-                                    child: Container(
-                                      width: 24,
-                                      height: 24,
-                                      decoration: BoxDecoration(
-                                        shape: BoxShape.circle,
-                                        color: _kamikazePlayerIndex ==
-                                                originalIndex
-                                            ? CupertinoColors.systemRed
-                                            : CupertinoColors
-                                                .tertiarySystemFill,
-                                        border: Border.all(
-                                          color: _kamikazePlayerIndex ==
-                                                  originalIndex
-                                              ? CupertinoColors.systemRed
-                                              : CupertinoColors.systemGrey,
-                                        ),
-                                      ),
-                                      child: _kamikazePlayerIndex ==
-                                              originalIndex
-                                          ? const Icon(
-                                              CupertinoIcons.exclamationmark,
-                                              size: 16,
-                                              color: CupertinoColors.white,
-                                            )
-                                          : null,
-                                    ),
-                                  ),
-                                  const SizedBox(width: 22),
-                                ],
+                                  inputFormatters: [
+                                    FilteringTextInputFormatter.digitsOnly,
+                                  ],
+                                  textInputAction: index ==
+                                          widget.gameSession.players.length - 1
+                                      ? TextInputAction.done
+                                      : TextInputAction.next,
+                                  controller:
+                                      _scoreControllerList[originalIndex],
+                                  placeholder:
+                                      AppLocalizations.of(context).points,
+                                  textAlign: TextAlign.center,
+                                  onSubmitted: (_) =>
+                                      _focusNextTextfield(originalIndex),
+                                  onChanged: (_) => setState(() {}),
+                                ),
                               ),
                             ),
                           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.4.8+526
+version: 0.4.8+529
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.4.8+525
+version: 0.4.8+526
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Rework kamikaze feature

**Related Issue(s):**  
Closes #104 

## Description  
Reworked the kamikaze feature. Removed the checkboxes from the players and bundled it into an `CupertinoActionSheet`

## Changes Made  
- [ ] Implemented new button for Kamikaze 
- [ ] Implemented Action Sheet for choosing the Kamikaze player
- [ ] Removed the Kamikaze checkbox from each player entry
- [ ] Removed column titles
- [ ] Bundles the navigation for the end of a round in a new function