### PR TITLE
Cancel button triggers confetti

### DIFF
--- a/lib/presentation/views/active_game_view.dart
+++ b/lib/presentation/views/active_game_view.dart
@@ -24,11 +24,19 @@ class ActiveGameView extends StatefulWidget {
 }
 
 class _ActiveGameViewState extends State<ActiveGameView> {
+  /// Constant value to represent a press on the cancel button in round view.
+  static const int kRoundCancelled = -1;
+
   final confettiController = ConfettiController(
     duration: const Duration(seconds: 10),
   );
+
   late final GameSession gameSession;
+
+  /// A list of the ranks for each player corresponding to their index in sortedPlayerIndices
   late List<int> denseRanks;
+
+  /// A list of player indices sorted by their scores in ascending order.
   late List<int> sortedPlayerIndices;
 
   @override
@@ -453,7 +461,8 @@ class _ActiveGameViewState extends State<ActiveGameView> {
       ),
     );
 
-    if (round == -1) return;
+    // If the user presses the cancel button
+    if (round == kRoundCancelled) return;
 
     if (widget.gameSession.isGameFinished && context.mounted) {
       _playFinishAnimation(context);

--- a/lib/presentation/views/active_game_view.dart
+++ b/lib/presentation/views/active_game_view.dart
@@ -453,6 +453,8 @@ class _ActiveGameViewState extends State<ActiveGameView> {
       ),
     );
 
+    if (round == -1) return;
+
     if (widget.gameSession.isGameFinished && context.mounted) {
       _playFinishAnimation(context);
     }

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -80,7 +80,7 @@ class _RoundViewState extends State<RoundView> {
             padding: EdgeInsets.zero,
             onPressed: () => {
               LocalStorageService.saveGameSessions(),
-              Navigator.pop(context)
+              Navigator.pop(context, -1)
             },
             child: Text(AppLocalizations.of(context).cancel),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.5.3+594
+version: 0.5.3+595
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Cancel button triggers confetti #139

**Related Issue(s):**  
Closes #139 

## Description  
Implemented the return number `-1` for signaling that the round was canceled and the confetti should not be played

## Changes Made  
- [ ] Adjusted `Navigator.pop()` on cancel button
- [ ] Implemented if statement for returning -1 from round view