### PR TITLE
Wrong marked round winner

### DIFF
--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -308,7 +308,10 @@ class _RoundViewState extends State<RoundView> {
 
     // Iterate through the scores to find the player with the minimum score
     for (int i = 1; i < scores.length; i++) {
-      if (scores[i] < minScore) {
+
+      // Check if the current score is less than the minimum score
+      // and is not negative (to avoid bonus points being considered)
+      if (scores[i] < minScore && !(scores[i] < 0)) {
         minScore = scores[i];
         winnerIndex = i;
       }

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -297,11 +297,17 @@ class _RoundViewState extends State<RoundView> {
   /// Returns 0 in the first round, as there is no previous round.
   int _getPreviousRoundWinnerIndex() {
     if (widget.roundNumber == 1) {
-      return 0; // If it's the first round, there's no previous round, so return 0.
+      return 0; // If it's the first round, the order should be the same as the players list.
     }
 
-    final scores = widget.gameSession.roundList[widget.roundNumber - 2].scoreUpdates;
-    return scores.indexOf(0);
+    final List<int> scores = widget.gameSession.roundList[widget.roundNumber - 2].scoreUpdates;
+    final int winnerIndex =  scores.indexOf(0);
+
+    // Fallback if no player has 0 points, which should not happen in a valid game.
+    if (winnerIndex == -1) {
+      return 0;
+    }
+    return winnerIndex;
   }
 
   /// Rotates the players list based on the previous round's winner.

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -301,7 +301,7 @@ class _RoundViewState extends State<RoundView> {
     }
 
     final List<int> scores = widget.gameSession.roundList[widget.roundNumber - 2].scoreUpdates;
-    final int winnerIndex =  scores.indexOf(0);
+    final int winnerIndex = scores.indexOf(0);
 
     // Fallback if no player has 0 points, which should not happen in a valid game.
     if (winnerIndex == -1) {

--- a/lib/presentation/views/round_view.dart
+++ b/lib/presentation/views/round_view.dart
@@ -294,30 +294,14 @@ class _RoundViewState extends State<RoundView> {
   }
 
   /// Gets the index of the player who won the previous round.
+  /// Returns 0 in the first round, as there is no previous round.
   int _getPreviousRoundWinnerIndex() {
     if (widget.roundNumber == 1) {
       return 0; // If it's the first round, there's no previous round, so return 0.
     }
 
-    final previousRound = widget.gameSession.roundList[widget.roundNumber - 2];
-    final scores = previousRound.scoreUpdates;
-
-    // Find the index of the player with the minimum score
-    int minScore = scores[0];
-    int winnerIndex = 0;
-
-    // Iterate through the scores to find the player with the minimum score
-    for (int i = 1; i < scores.length; i++) {
-
-      // Check if the current score is less than the minimum score
-      // and is not negative (to avoid bonus points being considered)
-      if (scores[i] < minScore && !(scores[i] < 0)) {
-        minScore = scores[i];
-        winnerIndex = i;
-      }
-    }
-
-    return winnerIndex;
+    final scores = widget.gameSession.roundList[widget.roundNumber - 2].scoreUpdates;
+    return scores.indexOf(0);
   }
 
   /// Rotates the players list based on the previous round's winner.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.5.3+595
+version: 0.5.3+596
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Wrong marked round winner

**Related Issue(s):**  
Closes #142 

## Description  
Fixed a bug so that if a player received bonus points he gets marked as round winner even though he did not won the round

## Changes Made  
- [ ] Simplified the method for determining the winner of the round. Its now that player who got 0 points in that round
      
