### PR TITLE
Game stays finished

### DIFF
--- a/lib/data/game_session.dart
+++ b/lib/data/game_session.dart
@@ -247,16 +247,22 @@ class GameSession extends ChangeNotifier {
   List<int> updatePoints() {
     List<int> bonusPlayers = [];
     _sumPoints();
+    bool limitExceeded = false;
+
     if (isPointsLimitEnabled) {
       bonusPlayers = _checkHundredPointsReached();
 
       for (int i = 0; i < playerScores.length; i++) {
         if (playerScores[i] > pointLimit) {
           isGameFinished = true;
+          limitExceeded = true;
           print('${players[i]} hat die 100 Punkte ueberschritten, '
               'deswegen wurde das Spiel beendet');
           setWinner();
         }
+      }
+      if (!limitExceeded) {
+        isGameFinished = false;
       }
     }
     notifyListeners();

--- a/lib/presentation/views/main_menu_view.dart
+++ b/lib/presentation/views/main_menu_view.dart
@@ -1,6 +1,7 @@
 import 'package:cabo_counter/core/constants.dart';
 import 'package:cabo_counter/core/custom_theme.dart';
 import 'package:cabo_counter/data/game_manager.dart';
+import 'package:cabo_counter/data/game_session.dart';
 import 'package:cabo_counter/l10n/generated/app_localizations.dart';
 import 'package:cabo_counter/presentation/views/active_game_view.dart';
 import 'package:cabo_counter/presentation/views/create_game_view.dart';
@@ -135,7 +136,7 @@ class _MainMenuViewState extends State<MainMenuView> {
                                     subtitle: Visibility(
                                         visible: session.isGameFinished,
                                         replacement: Text(
-                                          '${AppLocalizations.of(context).mode}: ${_translateGameMode(session.isPointsLimitEnabled)}',
+                                          '${AppLocalizations.of(context).mode}: ${_translateGameMode(session)}',
                                           style: const TextStyle(fontSize: 14),
                                         ),
                                         child: Text(
@@ -216,9 +217,9 @@ class _MainMenuViewState extends State<MainMenuView> {
 
   /// Translates the game mode boolean into the corresponding String.
   /// If [pointLimit] is true, it returns '101 Punkte', otherwise it returns 'Unbegrenzt'.
-  String _translateGameMode(bool isPointLimitEnabled) {
-    if (isPointLimitEnabled) {
-      return '${ConfigService.getPointLimit()} ${AppLocalizations.of(context).points}';
+  String _translateGameMode(GameSession gameSession) {
+    if (gameSession.isPointsLimitEnabled) {
+      return '${gameSession.pointLimit} ${AppLocalizations.of(context).points}';
     }
     return AppLocalizations.of(context).unlimited;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.5.3+597
+version: 0.5.3+598
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.5.3+596
+version: 0.5.3+597
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Game stays finished

**Related Issue(s):**  
Closes #140 

## Description  
Implemented that a game reopens when the scores get changed after rounds have been played

## Changes Made  
- [ ] Games open again when the point limit isnt reached after editing round scores
- [ ] Updated main menu: showing correct point limit
      
