### PR TITLE
Make game title optional

### DIFF
--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -55,8 +55,6 @@
   "create_game": "Spiel erstellen",
   "max_players_title": "Maximale Anzahl erreicht",
   "max_players_message": "Es können maximal 5 Spieler:innen hinzugefügt werden.",
-  "no_gameTitle_title": "Kein Titel",
-  "no_gameTitle_message": "Es muss ein Titel für das Spiel eingegeben werden.",
   "no_mode_title": "Kein Modus",
   "no_mode_message": "Es muss ein Spielmodus ausgewählt werden.",
   "min_players_title": "Zu wenig Spieler:innen",
@@ -77,6 +75,15 @@
     }
   },
   "unlimited_description": "Es wird so lange gespielt, bis ihr keine Lust mehr habt. Das Spiel kann jederzeit manuell beendet werden.",
+  "standard_game_title": "Spiel vom {date}",
+  "@fallback_title": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+
 
   "results": "Ergebnisse",
   "who_said_cabo": "Wer hat CABO gesagt?",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -55,8 +55,6 @@
   "create_game": "Create Game",
   "max_players_title": "Player Limit Reached",
   "max_players_message": "You can add a maximum of 5 players.",
-  "no_gameTitle_title": "Missing Game Title",
-  "no_gameTitle_message": "Please enter a title for your game.",
   "no_mode_title": "Game Mode Required",
   "no_mode_message": "Please select a game mode to continue",
   "min_players_title": "Too Few Players",
@@ -77,7 +75,14 @@
     }
   },
   "unlimited_description": "The game continues until you decide to stop playing. The game can be ended manually at any time.",
-
+  "standard_game_title": "Game on {date}",
+  "@fallback_title": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "results": "Results",
   "who_said_cabo": "Who called Cabo?",
   "kamikaze": "Kamikaze",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_en.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('de'),
-    Locale('en'),
+    Locale('en')
   ];
 
   /// No description provided for @app_name.
@@ -356,18 +356,6 @@ abstract class AppLocalizations {
   /// **'Es können maximal 5 Spieler:innen hinzugefügt werden.'**
   String get max_players_message;
 
-  /// No description provided for @no_gameTitle_title.
-  ///
-  /// In de, this message translates to:
-  /// **'Kein Titel'**
-  String get no_gameTitle_title;
-
-  /// No description provided for @no_gameTitle_message.
-  ///
-  /// In de, this message translates to:
-  /// **'Es muss ein Titel für das Spiel eingegeben werden.'**
-  String get no_gameTitle_message;
-
   /// No description provided for @no_mode_title.
   ///
   /// In de, this message translates to:
@@ -440,6 +428,12 @@ abstract class AppLocalizations {
   /// **'Es wird so lange gespielt, bis ihr keine Lust mehr habt. Das Spiel kann jederzeit manuell beendet werden.'**
   String get unlimited_description;
 
+  /// No description provided for @standard_game_title.
+  ///
+  /// In de, this message translates to:
+  /// **'Spiel vom {date}'**
+  String standard_game_title(Object date);
+
   /// No description provided for @results.
   ///
   /// In de, this message translates to:
@@ -487,11 +481,7 @@ abstract class AppLocalizations {
   /// In de, this message translates to:
   /// **'{playerCount, plural, =1{{names} hat exakt das Punktelimit von {pointLimit} Punkten erreicht und bekommt deshalb {bonusPoints} Punkte abgezogen!} other{{names} haben exakt das Punktelimit von {pointLimit} Punkten erreicht und bekommen deshalb jeweils {bonusPoints} Punkte abgezogen!}}'**
   String bonus_points_message(
-    int playerCount,
-    String names,
-    int pointLimit,
-    int bonusPoints,
-  );
+      int playerCount, String names, int pointLimit, int bonusPoints);
 
   /// No description provided for @end_of_game_title.
   ///
@@ -779,9 +769,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -144,13 +144,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Es können maximal 5 Spieler:innen hinzugefügt werden.';
 
   @override
-  String get no_gameTitle_title => 'Kein Titel';
-
-  @override
-  String get no_gameTitle_message =>
-      'Es muss ein Titel für das Spiel eingegeben werden.';
-
-  @override
   String get no_mode_title => 'Kein Modus';
 
   @override
@@ -192,6 +185,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Es wird so lange gespielt, bis ihr keine Lust mehr habt. Das Spiel kann jederzeit manuell beendet werden.';
 
   @override
+  String standard_game_title(Object date) {
+    return 'Spiel vom $date';
+  }
+
+  @override
   String get results => 'Ergebnisse';
 
   @override
@@ -214,11 +212,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String bonus_points_message(
-    int playerCount,
-    String names,
-    int pointLimit,
-    int bonusPoints,
-  ) {
+      int playerCount, String names, int pointLimit, int bonusPoints) {
     String _temp0 = intl.Intl.pluralLogic(
       playerCount,
       locale: localeName,

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -143,12 +143,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get max_players_message => 'You can add a maximum of 5 players.';
 
   @override
-  String get no_gameTitle_title => 'Missing Game Title';
-
-  @override
-  String get no_gameTitle_message => 'Please enter a title for your game.';
-
-  @override
   String get no_mode_title => 'Game Mode Required';
 
   @override
@@ -189,6 +183,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'The game continues until you decide to stop playing. The game can be ended manually at any time.';
 
   @override
+  String standard_game_title(Object date) {
+    return 'Game on $date';
+  }
+
+  @override
   String get results => 'Results';
 
   @override
@@ -211,11 +210,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String bonus_points_message(
-    int playerCount,
-    String names,
-    int pointLimit,
-    int bonusPoints,
-  ) {
+      int playerCount, String names, int pointLimit, int bonusPoints) {
     String _temp0 = intl.Intl.pluralLogic(
       playerCount,
       locale: localeName,

--- a/lib/presentation/views/home/create_game_view.dart
+++ b/lib/presentation/views/home/create_game_view.dart
@@ -11,10 +11,10 @@ import 'package:cabo_counter/services/config_service.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+import 'package:intl/intl.dart';
 import 'package:uuid/uuid.dart';
 
 enum CreateStatus {
-  noGameTitle,
   noModeSelected,
   minPlayers,
   maxPlayers,
@@ -115,10 +115,10 @@ class _CreateGameViewState extends State<CreateGameView> {
                     padding: const EdgeInsets.fromLTRB(15, 10, 10, 0),
                     child: CupertinoTextField(
                       decoration: const BoxDecoration(),
-                      maxLength: 20,
+                      maxLength: 24,
                       prefix: Text(AppLocalizations.of(context).name),
                       textAlign: TextAlign.right,
-                      placeholder: AppLocalizations.of(context).game_title,
+                      placeholder: getFallbackGameTitle(),
                       controller: _gameTitleTextController,
                       onSubmitted: (_) {
                         _playerNameFocusNodes.isNotEmpty
@@ -358,11 +358,6 @@ class _CreateGameViewState extends State<CreateGameView> {
   /// If any attribute is invalid, it shows a feedback dialog.
   /// If all attributes are valid, it calls the `_createGame` method.
   void _checkAllGameAttributes() {
-    if (_gameTitleTextController.text == '') {
-      _showFeedbackDialog(CreateStatus.noGameTitle);
-      return;
-    }
-
     if (gameMode == GameMode.none) {
       _showFeedbackDialog(CreateStatus.noModeSelected);
       return;
@@ -415,11 +410,6 @@ class _CreateGameViewState extends State<CreateGameView> {
   /// Returns the title and message for the dialog based on the [CreateStatus].
   (String, String) _getDialogContent(CreateStatus status) {
     switch (status) {
-      case CreateStatus.noGameTitle:
-        return (
-          AppLocalizations.of(context).no_gameTitle_title,
-          AppLocalizations.of(context).no_gameTitle_message
-        );
       case CreateStatus.noModeSelected:
         return (
           AppLocalizations.of(context).no_mode_title,
@@ -469,12 +459,16 @@ class _CreateGameViewState extends State<CreateGameView> {
       ));
     }
 
-    bool isPointsLimitEnabled = gameMode == GameMode.pointLimit;
+    final String gameTitle = _gameTitleTextController.text == ''
+        ? getFallbackGameTitle()
+        : _gameTitleTextController.text;
+
+    final bool isPointsLimitEnabled = gameMode == GameMode.pointLimit;
 
     GameSession gameSession = GameSession(
         gameId: gameId,
         createdAt: DateTime.now(),
-        gameTitle: _gameTitleTextController.text,
+        gameTitle: gameTitle,
         players: playerList,
         pointLimit: ConfigService.getPointLimit(),
         caboPenalty: ConfigService.getCaboPenalty(),
@@ -502,6 +496,24 @@ class _CreateGameViewState extends State<CreateGameView> {
       await Future.delayed(
           const Duration(milliseconds: Constants.kKeyboardDelay));
     }
+  }
+
+  /// Generates a fallback game title based on the current date and locale.
+  /// If the user does not provide a game title, this method will create one
+  /// using the current date formatted according to the user's locale.
+  String getFallbackGameTitle() {
+    final now = DateTime.now();
+    final String formattedDate;
+
+    Locale currentLocale = Localizations.localeOf(context);
+    switch (currentLocale.languageCode) {
+      case 'en':
+        formattedDate = DateFormat('MMMM d, y', 'en_US').format(now);
+      default:
+        formattedDate = DateFormat('dd.MM.yy').format(now);
+    }
+
+    return AppLocalizations.of(context).standard_game_title(formattedDate);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.6.2+793
+version: 0.6.3+799
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Make game title optional

**Related Issue(s):**  
Closes #145 

## Description  
Implemented a standard game title that will be assigned when no game is passed by the user

## Changes Made  
- [x] Implemented optional gameTitle in `CreateGameView`
- [x] Implemented method for creating a standard game title based on localization and date