### PR TITLE
Sharing Graph as Image

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -58,6 +58,6 @@ class Constants {
   /// Minimum duration in milliseconds that the skeleton screen should be displayed.
   static const int kMinimumSkeletonScreenDuration = 500;
 
-  /// Size of the icons used on the buttons in the main menu.
-  static const double mainMenuButtonIconSize = 25.0;
+  /// Size of the icons used on the buttons in the nav bar.
+  static const double navBarIconSize = 25.0;
 }

--- a/lib/presentation/views/home/active_game/graph_view.dart
+++ b/lib/presentation/views/home/active_game/graph_view.dart
@@ -1,7 +1,12 @@
+import 'dart:ui' as dart_ui;
+
+import 'package:cabo_counter/core/constants.dart';
 import 'package:cabo_counter/core/custom_theme.dart';
 import 'package:cabo_counter/data/dto/game_session.dart';
 import 'package:cabo_counter/l10n/generated/app_localizations.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 
 /// A widget that displays the cumulative scoring history of a game session as a line graph.
@@ -28,11 +33,19 @@ class _GraphViewState extends State<GraphView> {
     CustomTheme.graphColor5
   ];
 
+  /// Global key to access the state of the SfCartesianChart for image capturing.
+  final GlobalKey<SfCartesianChartState> _key = GlobalKey();
+
   @override
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(
           middle: Text(AppLocalizations.of(context).scoring_history),
+          trailing: IconButton(
+            onPressed: () => _shareImage(),
+            icon: const Icon(CupertinoIcons.share),
+            iconSize: Constants.mainMenuButtonIconSize,
+          ),
           previousPageTitle: AppLocalizations.of(context).overview,
         ),
         child: SafeArea(
@@ -58,9 +71,12 @@ class _GraphViewState extends State<GraphView> {
               ],
             ),
             child: SfCartesianChart(
+              key: _key,
+              backgroundColor: CustomTheme.backgroundColor,
               enableAxisAnimation: true,
               legend: const Legend(
-                  overflowMode: LegendItemOverflowMode.wrap,
+                  alignment: ChartAlignment.near,
+                  overflowMode: LegendItemOverflowMode.scroll,
                   isVisible: true,
                   position: LegendPosition.bottom),
               primaryXAxis: const NumericAxis(
@@ -135,5 +151,26 @@ class _GraphViewState extends State<GraphView> {
         color: lineColors[i],
       );
     });
+  }
+
+  /// Captures the current state of the graph as an image and shares it using the SharePlus package.
+  /// The image is saved as a PNG file and shared via available sharing options on the device.
+  /// The method uses a pixel ratio of 3.0 for high-resolution images.
+  Future<void> _shareImage() async {
+    final image = await _key.currentState?.toImage(pixelRatio: 5.0);
+    final byteData =
+        await image?.toByteData(format: dart_ui.ImageByteFormat.png);
+    if (byteData == null) return;
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [
+          XFile.fromData(
+            byteData.buffer.asUint8List(),
+            mimeType: 'image/png',
+            name: 'scoring_history.png',
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/presentation/views/home/active_game/graph_view.dart
+++ b/lib/presentation/views/home/active_game/graph_view.dart
@@ -44,7 +44,7 @@ class _GraphViewState extends State<GraphView> {
           trailing: IconButton(
             onPressed: () => _shareImage(),
             icon: const Icon(CupertinoIcons.share),
-            iconSize: Constants.mainMenuButtonIconSize,
+            iconSize: Constants.navBarIconSize,
           ),
           previousPageTitle: AppLocalizations.of(context).overview,
         ),

--- a/lib/presentation/views/home/active_game/graph_view.dart
+++ b/lib/presentation/views/home/active_game/graph_view.dart
@@ -155,7 +155,7 @@ class _GraphViewState extends State<GraphView> {
 
   /// Captures the current state of the graph as an image and shares it using the SharePlus package.
   /// The image is saved as a PNG file and shared via available sharing options on the device.
-  /// The method uses a pixel ratio of 3.0 for high-resolution images.
+  /// The method uses a pixel ratio of 5.0 for high-resolution images.
   Future<void> _shareImage() async {
     final image = await _key.currentState?.toImage(pixelRatio: 5.0);
     final byteData =

--- a/lib/presentation/views/home/main_menu_view.dart
+++ b/lib/presentation/views/home/main_menu_view.dart
@@ -104,7 +104,7 @@ class _MainMenuViewState extends State<MainMenuView> {
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [
                     IconButton(
-                        iconSize: Constants.mainMenuButtonIconSize,
+                        iconSize: Constants.navBarIconSize,
                         onPressed: () {
                           Navigator.push(
                             context,
@@ -164,7 +164,7 @@ class _MainMenuViewState extends State<MainMenuView> {
                         onPressed: showMenu,
                         padding: EdgeInsets.zero,
                         icon: const Icon(CupertinoIcons.arrow_up_arrow_down),
-                        iconSize: Constants.mainMenuButtonIconSize,
+                        iconSize: Constants.navBarIconSize,
                       ),
                     ),
                   ],
@@ -180,7 +180,7 @@ class _MainMenuViewState extends State<MainMenuView> {
                     ),
                   ),
                   icon: const Icon(CupertinoIcons.add),
-                  iconSize: Constants.mainMenuButtonIconSize,
+                  iconSize: Constants.navBarIconSize,
                 ),
               ),
               child: CupertinoPageScaffold(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.6.4+828
+version: 0.6.5+842
 
 environment:
   sdk: ^3.5.4
@@ -38,6 +38,7 @@ dependencies:
   provider: ^6.1.5+1
   shimmer: ^3.0.0
   pull_down_button: ^0.10.2
+  share_plus: ^11.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#  Sharing Graph as Image

**Related Issue(s):**  
Closes #177 

## Description  
Implemented a button for sharing the graph as an image with the `toImage`-Method of the graph package