### PR TITLE
Games and main menu dont open the corresponding game you clicked on

### DIFF
--- a/lib/presentation/views/home/main_menu_view.dart
+++ b/lib/presentation/views/home/main_menu_view.dart
@@ -70,6 +70,8 @@ class _MainMenuViewState extends State<MainMenuView> {
           });
         }
         displayedGames = List.from(gameManager.gameList);
+        _sortGames(
+            sortOption: currentSortOption, sortDirection: currentSortDirection);
       });
     }).catchError((error) {
       print('[MainMenuView] $error');
@@ -272,8 +274,7 @@ class _MainMenuViewState extends State<MainMenuView> {
                                           ],
                                         ),
                                         onTap: () {
-                                          final session =
-                                              gameManager.gameList[index];
+                                          final session = displayedGames[index];
                                           Navigator.push(
                                             context,
                                             CupertinoPageRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cabo_counter
 description: "Mobile app for the card game Cabo"
 publish_to: 'none'
 
-version: 0.6.4+828
+version: 0.6.4+830
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
# Games and main menu dont open the corresponding game you clicked on

**Related Issue(s):**  
Closes #178 

## Description  
Fixed a bug where you clicked on a game in main menu and it opened an other game

## Changes Made  
- [x] Corrected list accessed from `gameManger.gameList` to `displayedGames`
- [x] Added `sortGames()` call in `initState()` method so that the list will be sorted rightly at startup