### PR TITLE
RangeError on first round win

### DIFF
--- a/lib/presentation/views/home/active_game/active_game_view.dart
+++ b/lib/presentation/views/home/active_game/active_game_view.dart
@@ -349,7 +349,7 @@ class _ActiveGameViewState extends State<ActiveGameView> {
       context: context,
       title: Text(AppLocalizations.of(context).end_game_title),
       message: Text(AppLocalizations.of(context).end_game_message),
-      actions: [endGameAction, cancelAction],
+      actions: [cancelAction, endGameAction],
     );
   }
 

--- a/lib/presentation/views/home/active_game/round_view.dart
+++ b/lib/presentation/views/home/active_game/round_view.dart
@@ -514,7 +514,8 @@ class _RoundViewState extends State<RoundView> {
           widget.roundNumber, roundScores, _caboPlayerIndex);
     }
     List<int> bonusPlayers = widget.gameSession.updatePoints();
-    if (widget.roundNumber == widget.gameSession.roundNumber) {
+    if (widget.roundNumber == widget.gameSession.roundNumber &&
+        !widget.gameSession.isGameFinished) {
       widget.gameSession.increaseRound();
     }
     return bonusPlayers;


### PR DESCRIPTION
# RangeError on first round win

**Related Issue(s):**  
Closes #212 

## Description  
Fixed Error by extending an if statement to check wheter `isGameFinished` equals `false`and only then creates a new round

## Changes Made  
- [x] Fixed bug
- [x] Changed popup actions order