### PR TITLE
Rotate the shuffle player

### DIFF
--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -154,6 +154,8 @@
   "cabo_penalty": "Cabo-Strafe",
   "point_limit": "Punkte-Limit",
   "standard_mode": "Standard-Modus",
+  "rotate_shuffler": "Mischer:in rotieren",
+  "shuffler_rotation_info": "Standardmäßig mischt die Person, welche die letzte Runde verloren hat. Aktiviere diese Option um die Rolle jede Runde in Spielreihenfolge zu rotieren.",
   "reset_to_default": "Auf Standard zurücksetzen",
   "reset_config_title": "Einstellungen zurücksetzen",
   "reset_config_message": "Möchtest du deine Einstellungen zurücksetzen?",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -152,6 +152,8 @@
   "cabo_penalty": "Cabo Penalty",
   "point_limit": "Point Limit",
   "standard_mode": "Default Mode",
+  "rotate_shuffler": "Rotate Shuffler",
+  "shuffler_rotation_info": "By default, the person who lost the last round shuffles. Enable this option to rotate the role each round in game order.",
   "reset_to_default": "Reset to Default",
   "reset_config_title": "Reset Settings",
   "reset_config_message": "Do you want to reset your settings?",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -657,6 +657,18 @@ abstract class AppLocalizations {
   /// **'Standard-Modus'**
   String get standard_mode;
 
+  /// No description provided for @rotate_shuffler.
+  ///
+  /// In de, this message translates to:
+  /// **'Mischer:in rotieren'**
+  String get rotate_shuffler;
+
+  /// No description provided for @shuffler_rotation_info.
+  ///
+  /// In de, this message translates to:
+  /// **'Standardmäßig mischt die Person, welche die letzte Runde verloren hat. Aktiviere diese Option um die Rolle jede Runde in Spielreihenfolge zu rotieren.'**
+  String get shuffler_rotation_info;
+
   /// No description provided for @reset_to_default.
   ///
   /// In de, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -326,6 +326,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get standard_mode => 'Standard-Modus';
 
   @override
+  String get rotate_shuffler => 'Mischer:in rotieren';
+
+  @override
+  String get shuffler_rotation_info =>
+      'Standardmäßig mischt die Person, welche die letzte Runde verloren hat. Aktiviere diese Option um die Rolle jede Runde in Spielreihenfolge zu rotieren.';
+
+  @override
   String get reset_to_default => 'Auf Standard zurücksetzen';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -322,6 +322,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get standard_mode => 'Default Mode';
 
   @override
+  String get rotate_shuffler => 'Rotate Shuffler';
+
+  @override
+  String get shuffler_rotation_info =>
+      'By default, the person who lost the last round shuffles. Enable this option to rotate the role each round in game order.';
+
+  @override
   String get reset_to_default => 'Reset to Default';
 
   @override

--- a/lib/presentation/components/widgets/custom_form_row.dart
+++ b/lib/presentation/components/widgets/custom_form_row.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:cabo_counter/core/custom_theme.dart';
 import 'package:cabo_counter/presentation/components/widgets/custom_stepper.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 /// A customizable form row widget with a prefix icon, text, and optional suffix widget.
 ///
@@ -28,6 +31,7 @@ class _CustomFormRowState extends State<CustomFormRow> {
   @override
   void initState() {
     super.initState();
+    print('Suffix widget is : ${widget.suffixWidget.runtimeType}');
   }
 
   @override
@@ -63,6 +67,12 @@ class _CustomFormRowState extends State<CustomFormRow> {
         suffixWidget is CupertinoListTileChevron ||
         suffixWidget is Row) {
       return const EdgeInsets.fromLTRB(15, 10, 8, 10);
+    } else if (suffixWidget is Material) {
+      if (Platform.isIOS) {
+        return const EdgeInsets.fromLTRB(15, 0, 10, 0);
+      } else {
+        return const EdgeInsets.fromLTRB(15, 0, 8, 0);
+      }
     } else {
       return const EdgeInsets.symmetric(vertical: 10, horizontal: 15);
     }

--- a/lib/presentation/components/widgets/custom_form_row.dart
+++ b/lib/presentation/components/widgets/custom_form_row.dart
@@ -31,7 +31,6 @@ class _CustomFormRowState extends State<CustomFormRow> {
   @override
   void initState() {
     super.initState();
-    print('Suffix widget is : ${widget.suffixWidget.runtimeType}');
   }
 
   @override

--- a/lib/presentation/views/home/active_game/round_view.dart
+++ b/lib/presentation/views/home/active_game/round_view.dart
@@ -5,6 +5,7 @@ import 'package:cabo_counter/data/dto/game_session.dart';
 import 'package:cabo_counter/l10n/generated/app_localizations.dart';
 import 'package:cabo_counter/presentation/components/widgets/custom_button.dart';
 import 'package:cabo_counter/presentation/components/widgets/kamikaze_sheet.dart';
+import 'package:cabo_counter/services/config_service.dart';
 import 'package:cabo_counter/services/icon_service.dart';
 import 'package:cabo_counter/services/popup_service.dart';
 import 'package:flutter/cupertino.dart';
@@ -349,11 +350,18 @@ class _RoundViewState extends State<RoundView> {
   /// Determines which player is responsible for shuffling the cards.
   /// In the first round, the first player shuffles. In subsequent rounds,
   /// the player with the highest score from the previous round (round loser)
-  /// shuffles.
+  /// shuffles. If rotate shuffler is enabled in the configuration,
+  /// the shuffler rotates among players each round.
   int _getShufflePlayerIndex() {
     // In the first round the first player shuffles the cards
     if (widget.roundNumber == 1) {
       return 0;
+    }
+
+    // If the configuration is set to rotate the shuffler, calculate the
+    // shuffler index according to the current round number and amount of players
+    if (ConfigService.getRotateShuffler()) {
+      return (widget.roundNumber - 1) % widget.gameSession.players.length;
     }
 
     final List<int> scores =

--- a/lib/presentation/views/home/settings_view.dart
+++ b/lib/presentation/views/home/settings_view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cabo_counter/core/constants.dart';
 import 'package:cabo_counter/core/custom_theme.dart';
 import 'package:cabo_counter/core/enums.dart';
@@ -13,6 +15,7 @@ import 'package:cabo_counter/services/icon_service.dart';
 import 'package:cabo_counter/services/popup_service.dart';
 import 'package:cabo_counter/services/version_service.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -31,6 +34,7 @@ class _SettingsViewState extends State<SettingsView> {
   UniqueKey _stepperKey1 = UniqueKey();
   UniqueKey _stepperKey2 = UniqueKey();
   GameMode defaultMode = ConfigService.getGameMode();
+  bool rotateShuffler = ConfigService.getRotateShuffler();
 
   @override
   void initState() {
@@ -62,8 +66,8 @@ class _SettingsViewState extends State<SettingsView> {
                 child: CupertinoFormSection.insetGrouped(
                     footer: Padding(
                       padding: const EdgeInsets.only(top: 5.0),
-                      child:
-                          Text(AppLocalizations.of(context).config_change_info),
+                      child: Text(
+                          AppLocalizations.of(context).shuffler_rotation_info),
                     ),
                     backgroundColor: CustomTheme.backgroundColor,
                     margin: EdgeInsets.zero,
@@ -134,6 +138,37 @@ class _SettingsViewState extends State<SettingsView> {
                           ConfigService.setGameMode(defaultMode);
                         },
                       ),
+                      CustomFormRow(
+                        prefixText:
+                            AppLocalizations.of(context).rotate_shuffler,
+                        prefixIcon: IconService.shuffle_cards,
+                        suffixWidget: Material(
+                          color: Colors.transparent,
+                          child: Switch.adaptive(
+                              activeTrackColor: CustomTheme.primaryColor,
+                              inactiveThumbColor: Colors.white,
+                              value: rotateShuffler,
+                              onChanged: (switchValue) {
+                                setState(() {
+                                  ConfigService.setRotateShuffler(switchValue);
+                                  rotateShuffler = switchValue;
+                                });
+                              }),
+                        ),
+                        onPressed: () => showConfirmPopup(),
+                      ),
+                    ])),
+            Padding(
+                padding: const EdgeInsets.fromLTRB(10, 15, 10, 0),
+                child: CupertinoFormSection.insetGrouped(
+                    footer: Padding(
+                      padding: const EdgeInsets.only(top: 5.0),
+                      child:
+                          Text(AppLocalizations.of(context).config_change_info),
+                    ),
+                    backgroundColor: CustomTheme.backgroundColor,
+                    margin: EdgeInsets.zero,
+                    children: [
                       CustomFormRow(
                         prefixText:
                             AppLocalizations.of(context).reset_to_default,

--- a/lib/presentation/views/home/settings_view.dart
+++ b/lib/presentation/views/home/settings_view.dart
@@ -153,7 +153,6 @@ class _SettingsViewState extends State<SettingsView> {
                                 });
                               }),
                         ),
-                        onPressed: () => showConfirmPopup(),
                       ),
                     ])),
             Padding(

--- a/lib/presentation/views/home/settings_view.dart
+++ b/lib/presentation/views/home/settings_view.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:cabo_counter/core/constants.dart';
 import 'package:cabo_counter/core/custom_theme.dart';
 import 'package:cabo_counter/core/enums.dart';

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -83,7 +83,7 @@ class ConfigService {
   /// Default value of [_rotateShuffler]
   static const bool _defaultRotateShuffler = false;
 
-  /// Key for the stored sorting direction.
+  /// Key for the stored rotate shuffler flag.
   static const String _keyRotateShuffler = 'rotateShuffler';
 
   static Future<void> initConfig() async {

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -231,6 +231,9 @@ class ConfigService {
     _showActiveGamesOnly = showActiveGamesOnly;
   }
 
+  /// Getter for the rotate shuffler flag.
+  static bool getRotateShuffler() => _rotateShuffler;
+
   /// Setter for the rotate shuffler flag.
   /// [rotateShuffler] is the new value to be set.
   static Future<void> setRotateShuffler(bool rotateShuffler) async {
@@ -238,9 +241,6 @@ class ConfigService {
     await prefs.setBool(_keyRotateShuffler, rotateShuffler);
     _rotateShuffler = rotateShuffler;
   }
-
-  /// Getter for the rotate shuffler flag.
-  static bool getRotateShuffler() => _rotateShuffler;
 
   /// Resets the user configuration to default values.
   static Future<void> resetUserConfig() async {

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -76,6 +76,16 @@ class ConfigService {
   /// Key for the stored show active games only flag.
   static const String _keyShowActiveGamesOnly = 'showActiveGamesOnly';
 
+  /// Should the shuffle player rotate?
+  /// true = rotate shuffle player, false = last round loser shuffles
+  static bool _rotateShuffler = false;
+
+  /// Default value of [_rotateShuffler]
+  static const bool _defaultRotateShuffler = false;
+
+  /// Key for the stored sorting direction.
+  static const String _keyRotateShuffler = 'rotateShuffler';
+
   static Future<void> initConfig() async {
     final prefs = await SharedPreferences.getInstance();
 
@@ -91,6 +101,8 @@ class ConfigService {
         prefs.getBool(_keySortingDirection) ?? _defaultSortingDirection;
     _showActiveGamesOnly =
         prefs.getBool(_keyShowActiveGamesOnly) ?? _defaultShowActiveGamesOnly;
+    _rotateShuffler =
+        prefs.getBool(_keyRotateShuffler) ?? _defaultRotateShuffler;
 
     // Save the initial values to SharedPreferences
     prefs.setInt(_keyPointLimit, _pointLimit);
@@ -100,6 +112,7 @@ class ConfigService {
     prefs.setBool(_keySortingOption, _sortingOption);
     prefs.setBool(_keySortingDirection, _sortingDirection);
     prefs.setBool(_keyShowActiveGamesOnly, _showActiveGamesOnly);
+    prefs.setBool(_keyRotateShuffler, _rotateShuffler);
   }
 
   /// Retrieves the current game mode.
@@ -207,6 +220,7 @@ class ConfigService {
     _sortingDirection = direction;
   }
 
+  /// Getter for the show active games only flag.
   static bool getShowActiveGamesOnly() => _showActiveGamesOnly;
 
   /// Setter for the show active games only flag.
@@ -216,6 +230,17 @@ class ConfigService {
     await prefs.setBool(_keyShowActiveGamesOnly, showActiveGamesOnly);
     _showActiveGamesOnly = showActiveGamesOnly;
   }
+
+  /// Setter for the rotate shuffler flag.
+  /// [rotateShuffler] is the new value to be set.
+  static Future<void> setRotateShuffler(bool rotateShuffler) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_keyRotateShuffler, rotateShuffler);
+    _rotateShuffler = rotateShuffler;
+  }
+
+  /// Getter for the rotate shuffler flag.
+  static bool getRotateShuffler() => _rotateShuffler;
 
   /// Resets the user configuration to default values.
   static Future<void> resetUserConfig() async {

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -135,6 +135,7 @@ abstract class IconService {
       ? CupertinoIcons.eye_slash_fill
       : Icons.visibility_off_rounded;
 
+  /// Icon for shuffle rotation.
   static IconData get shuffle_cards => Platform.isIOS
       ? CupertinoIcons.rectangle_fill_on_rectangle_angled_fill
       : Icons.casino;

--- a/lib/services/icon_service.dart
+++ b/lib/services/icon_service.dart
@@ -134,4 +134,8 @@ abstract class IconService {
   static IconData get visibility_off => Platform.isIOS
       ? CupertinoIcons.eye_slash_fill
       : Icons.visibility_off_rounded;
+
+  static IconData get shuffle_cards => Platform.isIOS
+      ? CupertinoIcons.rectangle_fill_on_rectangle_angled_fill
+      : Icons.casino;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cabo_counter
-version: 1.0.3+1015
+version: 1.0.3+1018
 publish_to: none
 
 environment:
@@ -14,6 +14,7 @@ dependencies:
   drift_flutter: ^0.2.4
   file_picker: ^10.1.2
   file_saver: ^0.2.6
+  fluentui_system_icons: ^1.1.273
   flutter:
     sdk: flutter
   flutter_keyboard_visibility: ^6.0.0
@@ -26,6 +27,7 @@ dependencies:
       ref: master
   font_awesome_flutter: ^10.8.0
   google_fonts: ^6.3.0
+  hugeicons: ^1.1.2
   intl: any
   json_schema: ^5.2.1
   package_info_plus: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cabo_counter
-version: 1.0.3+1018
+version: 1.0.3+1019
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cabo_counter
-version: 1.0.5+1019
+version: 1.0.5+1020
 publish_to: none
 
 environment:
@@ -14,7 +14,6 @@ dependencies:
   drift_flutter: ^0.2.4
   file_picker: ^10.1.2
   file_saver: ^0.2.6
-  fluentui_system_icons: ^1.1.273
   flutter:
     sdk: flutter
   flutter_keyboard_visibility: ^6.0.0
@@ -27,7 +26,6 @@ dependencies:
       ref: master
   font_awesome_flutter: ^10.8.0
   google_fonts: ^6.3.0
-  hugeicons: ^1.1.2
   intl: any
   json_schema: ^5.2.1
   package_info_plus: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cabo_counter
-version: 1.0.3+1019
+version: 1.0.5+1019
 publish_to: none
 
 environment:


### PR DESCRIPTION
# Rotate the shuffle player

**Related Issue(s):**  
Closes #223 

## Description  
Implemented an option in the settings to let the shuffle player rotate through the players with every round played

## Changes Made  
- Implemented local config for saving the rotate players state
- Implemented new settings tile for enabling rotate players
- Added if clause in shuffle player calculation