### PR TITLE
Vibration dont work on games with point limit

### DIFF
--- a/lib/data/dto/game_manager.dart
+++ b/lib/data/dto/game_manager.dart
@@ -79,11 +79,10 @@ class GameManager extends ChangeNotifier {
     gameList[index].endGame();
     db.gameSessionDao.endGame(gameId);
     notifyListeners();
-    _vibrateIfPossible();
   }
 
   /// Vibrates the device if vibration is supported.
-  void _vibrateIfPossible() async {
+  void vibrateIfPossible() async {
     try {
       if (await Vibrate.canVibrate) {
         Vibrate.feedback(FeedbackType.success);

--- a/lib/data/dto/game_session.dart
+++ b/lib/data/dto/game_session.dart
@@ -1,4 +1,5 @@
 import 'package:cabo_counter/data/db/database.dart';
+import 'package:cabo_counter/data/dto/game_manager.dart';
 import 'package:cabo_counter/data/dto/player.dart';
 import 'package:cabo_counter/data/dto/round.dart';
 import 'package:flutter/cupertino.dart';
@@ -295,6 +296,8 @@ class GameSession extends ChangeNotifier {
       winner = lowestPlayers.first;
     }
     db.gameSessionDao.setWinner(gameId, winner);
+    gameManager.vibrateIfPossible();
+
     notifyListeners();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cabo_counter
-version: 1.0.6+1047
+version: 1.0.6+1049
 publish_to: none
 
 environment:


### PR DESCRIPTION
# Vibration dont work on games with point limit

**Related Issue(s):**  
Closes #231 

## Description  
Fixed a bug where the vibration only worked on games with a point limit.