### PR TITLE
Fixes keyboard type when entering points of a round to numeric only t…

### DIFF
--- a/lib/presentation/views/home/active_game/round_view.dart
+++ b/lib/presentation/views/home/active_game/round_view.dart
@@ -237,11 +237,7 @@ class _RoundViewState extends State<RoundView> {
                                 child: CupertinoTextField(
                                   maxLength: 3,
                                   focusNode: _focusNodeList[originalIndex],
-                                  keyboardType:
-                                      const TextInputType.numberWithOptions(
-                                    signed: true,
-                                    decimal: false,
-                                  ),
+                                  keyboardType: TextInputType.number,
                                   inputFormatters: [
                                     FilteringTextInputFormatter.digitsOnly,
                                   ],

--- a/lib/presentation/views/home/active_game/round_view.dart
+++ b/lib/presentation/views/home/active_game/round_view.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:io';
 
 import 'package:cabo_counter/core/custom_theme.dart';
 import 'package:cabo_counter/data/dto/game_session.dart';
@@ -237,7 +238,12 @@ class _RoundViewState extends State<RoundView> {
                                 child: CupertinoTextField(
                                   maxLength: 3,
                                   focusNode: _focusNodeList[originalIndex],
-                                  keyboardType: TextInputType.number,
+                                  keyboardType: Platform.isIOS
+                                      ? TextInputType.number
+                                      : const TextInputType.numberWithOptions(
+                                          signed: true,
+                                          decimal: false,
+                                        ),
                                   inputFormatters: [
                                     FilteringTextInputFormatter.digitsOnly,
                                   ],


### PR DESCRIPTION
# Fixes Keyboard type when entering points on a round

## Description  
Before when entering the points for a round for each player the keyboard was alphanumeric, I've changed it to be numeric only. 

## Changes Made  
- [X] Added new feature X  
- [ ] Fixed bug in component Y  
- [ ] Refactored module Z for better performance  
- [ ] Updated dependencies
      
## Screenshots/GIFs (if applicable)  

*After:*  
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-13 at 16 08 57" src="https://github.com/user-attachments/assets/630809f8-10a5-41ec-a551-77d64f3d31f7" />
<img width="1080" height="2424" alt="Screenshot_20260513_162521" src="https://github.com/user-attachments/assets/ec9071b7-f378-4f53-9c27-0df95e32489d" />
